### PR TITLE
Bugfix & webpack proxy config

### DIFF
--- a/backend/api/login/views.py
+++ b/backend/api/login/views.py
@@ -58,7 +58,9 @@ class LoginRequest(APIView):
             logger.error(e.args[0])
             return JsonResponse({'success': False, 'message': e.args[0]})
 
-        request.session['tree'] = tree
+        request.session['list'] = sugang_list
+        # TODO: fix error
+        # request.session['tree'] = tree
         request.session.set_expiry(6000)
         return JsonResponse({'success': True, 'message': str(request.session['list'])})
 

--- a/frontend/src/js/filerequest.js
+++ b/frontend/src/js/filerequest.js
@@ -1,8 +1,8 @@
 // Interface for Elm that handles HTTP form request & intercepts response
 // Elm 0.18 does not support 'file input request' in native.
-var app = Elm.Main.fullscreen();
+var elmApp = Elm.Main.fullscreen();
 
-app.ports.fileRequest.subscribe(function (param) {
+elmApp.ports.fileRequest.subscribe(function (param) {
   var split = param.split('@');
   var id = split[0];
   var url = split[1];

--- a/frontend/src/static/index.js
+++ b/frontend/src/static/index.js
@@ -1,8 +1,8 @@
-'use strict';
+//'use strict';
 
 require('./styles/index.css')
 
-var Elm = require('../elm/Main.elm');
+Elm = require('../elm/Main.elm');
 var mountNode = document.getElementById('main');
 
 var app = Elm.Main.embed(mountNode);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,7 @@ var commonConfig = {
   output: {
     path:       outputPath,
     filename:   outputFilename,
-    publicPath: '/static/'
+    publicPath: '/'
   },
 
   resolve: {
@@ -62,12 +62,13 @@ if ( TARGET_ENV === 'development' ) {
     ],
 
     devServer: {
-      // serve static/index.html in place of 404 responses
-      historyApiFallback: {
-        rewrites: [
-          { from: /./, to: '/static/index.html' },
-        ]
-      }
+      historyApiFallback: true,
+      proxy: [
+        {
+          context: ['/api'],
+          target: 'http://localhost:8000',
+        }
+      ]
     },
 
     module: {


### PR DESCRIPTION
Hotfix for frontend page runtime error ddue to routing.
Also added webpack proxy config, which allows you to communicate with backend server.
So now you should:
- run `npm start`
- run `manage.py runserver`
- connect `localhost:8080/login`

to fully test current page.