### PR TITLE
changed python3 to python in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install --save-dev
 #### Backend
 
 ```bash
-python3 backend/manage.py runserver
+python backend/manage.py runserver
 ```
 
 #### Frontend


### PR DESCRIPTION
Since we use virtualenv, we don't have to execute server with `python3`. `python` is right.