### PR TITLE
Refactored TreeLoader not to get `course_model` argument

### DIFF
--- a/backend/api/main/tests.py
+++ b/backend/api/main/tests.py
@@ -5,7 +5,6 @@ import json
 import pickle
 import os
 from api.main.tree import tree_to_json
-from core.models import Course
 from core.rule.tree import TreeLoader
 
 
@@ -17,7 +16,7 @@ class TestTreeToJson(TestCase):
 
         file = open(sugang_list_dir, 'rb')
         self.sample_sugang_list = pickle.load(file)['credit_info']
-        self.tree = TreeLoader(self.sample_rule, sample_metadata, Course)
+        self.tree = TreeLoader(self.sample_rule, sample_metadata)
         self.tree.eval_tree(self.sample_sugang_list)
 
     def test_tree_to_json(self):

--- a/backend/core/management/commands/treetest.py
+++ b/backend/core/management/commands/treetest.py
@@ -29,6 +29,6 @@ class Command(BaseCommand):
             self.stdout.write('error: invalid credential.')
             return
 
-        tree_node = TreeLoader(rule, metadata, Course)
+        tree_node = TreeLoader(rule, metadata)
         tree_node.eval_tree(taken_list)
         self.stdout.write(tree_node.tree_into_str())

--- a/backend/core/rule/tree.py
+++ b/backend/core/rule/tree.py
@@ -5,6 +5,7 @@ from core.rule.functions import and_func, make_func, if_func_list
 import os
 import logging.config
 from django.conf import settings
+from ..models import Course, Replace
 
 logging.config.dictConfig(settings.LOGGING)
 logger = logging.getLogger('backend')
@@ -44,13 +45,12 @@ class TreeLoader(object):
     Raises:
         TreeLoaderException: any error in loader
     """
-    def __init__(self, rule_name, metadata, course_model):
+    def __init__(self, rule_name, metadata):
         """Constructor of TreeLoader.
 
         Args:
             rule_name: rule file name in ./rules, excluding extension .yml
             metadata: data of any other information needed evaluating tree
-            course_model: `Course` model object
         """
         base_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -66,13 +66,7 @@ class TreeLoader(object):
         # Metadata
         self.metadata = metadata
 
-        # model `Course`: because model in Django can be used only when server runs.
-        self.course_model = course_model
         self.default_properties = {
-
-            # course model object is passed by properties
-            'course_model': self.course_model,
-
             # if this value is True, falsy node will be hidden
             'hide_false': False,
 
@@ -111,7 +105,7 @@ class TreeLoader(object):
                     subarea = course[1:]
 
                     # filter with Django model
-                    code_list = [item.code for item in self.course_model.objects.filter(subarea=subarea)]
+                    code_list = [item.code for item in Course.objects.filter(subarea=subarea)]
                     code_set = set(code_list)
 
                     # expand tree
@@ -126,7 +120,7 @@ class TreeLoader(object):
                     dept, category, year = t[1], t[2], int(t[3])
 
                     # filter with Django model
-                    code_list = [item.code for item in self.course_model.objects.filter(
+                    code_list = [item.code for item in Course.objects.filter(
                         dept=dept,
                         category=category,
                         year=year,
@@ -159,7 +153,6 @@ class TreeLoader(object):
 
                 # construct property dictionary
                 properties = {
-                    'course_model': self.course_model,
                     'hide_false': hide_false,
                     'credit_info': [0, required_credit, sum_false],
                     'main_node': main_node,
@@ -279,7 +272,7 @@ class TreeNode(object):
             self.children = []
             try:
                 # get information of course by fetching database
-                filtered_course = properties['course_model'].objects.filter(code=self.data)[0]
+                filtered_course = Course.objects.filter(code=self.data)[0]
                 self.namespace = filtered_course.title
                 self.credit = filtered_course.credit
 

--- a/backend/core/rule/tree.py
+++ b/backend/core/rule/tree.py
@@ -5,7 +5,7 @@ from core.rule.functions import and_func, make_func, if_func_list
 import os
 import logging.config
 from django.conf import settings
-from ..models import Course, Replace
+from core.models import Course, Replace
 
 logging.config.dictConfig(settings.LOGGING)
 logger = logging.getLogger('backend')

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -3,7 +3,6 @@ from django.test import TestCase
 from django.conf import settings
 import pickle
 import os
-from core.models import Course
 from core.rule.tree import TreeLoader, TreeNode, TreeLoaderException
 
 
@@ -22,9 +21,9 @@ class TestRuleTree(TestCase):
         self.sample_sugang_list = pickle.load(file)['credit_info']
 
     def test_tree_creation(self):
-        self.assertRaises(TreeLoaderException, TreeLoader, 'non_existing_rule', None, Course)
+        self.assertRaises(TreeLoaderException, TreeLoader, 'non_existing_rule', None)
 
-        tree = TreeLoader(self.sample_rule, {}, Course)
+        tree = TreeLoader(self.sample_rule, {})
         node_count = self.recur_node_count(tree.base_node)
         self.assertEqual(node_count, 340)  # print(node_count) to get proper value
         tree_str = tree.tree_into_str()
@@ -48,7 +47,7 @@ class TestRuleTree(TestCase):
 
     def test_tree_evaluation(self):
         sample_metadata = {"teps": 2}
-        tree = TreeLoader(self.sample_rule, sample_metadata, Course)
+        tree = TreeLoader(self.sample_rule, sample_metadata)
         tree.eval_tree(self.sample_sugang_list)
         self.recur_tree_evaluation(tree.base_node)
         tree_str = tree.tree_into_str()


### PR DESCRIPTION
Originally, we should give `course_model` argument which indicates Django model `Course`, because python's parent package import is not allowed in standalone scripting.

But, since we have Django command `treetest`, we can do backward import, and finally corrected awkward code.