### PR TITLE
Apply Replace model into tree evaluation

### DIFF
--- a/backend/core/rule/tree.py
+++ b/backend/core/rule/tree.py
@@ -194,8 +194,17 @@ class TreeLoader(object):
             data of self.base_node
         """
 
+        # First, construct codeset before evaluation process
+        codeset = {}
+        # iterate over taken list, and lookup Replace model
+        for course in taken_list:
+            code = course['code']
+            # place its code in head of list, so that the replace code
+            # acts as a fallback of original course code
+            codeset[code] = [code] + [replace.to_code for replace in Replace.objects.filter(from_code=code)]
+
         # clone taken_list because it's modified
-        self.base_node.eval_children(list(taken_list))
+        self.base_node.eval_children(list(taken_list), codeset)
         return self.base_node.data
 
     def tree_into_str(self):
@@ -359,16 +368,6 @@ class TreeNode(object):
         Returns:
             None
         """
-
-        # If codeset is empty, construct it first
-        if codeset is None:
-            codeset = {}
-            # iterate over taken list, and lookup Replace model
-            for course in taken_list:
-                code = course['code']
-                # place its code in head of list, so that the replace code
-                # acts as a fallback of original course code
-                codeset[code] = [code] + [replace.to_code for replace in Replace.objects.filter(from_code=code)]
 
         # First, evaluate all children so that itself can be evaluated directly
         for i, child in enumerate(self.children):

--- a/backend/core/rule/tree.py
+++ b/backend/core/rule/tree.py
@@ -420,6 +420,7 @@ class TreeNode(object):
                             # if matches, consume it
                             if code == child.data:
                                 del taken_list[i]
+                                del codeset[code]
 
         # If it is just plain course code number, it can be evaluated by
         # looking up course taken list.

--- a/backend/core/rule/tree.py
+++ b/backend/core/rule/tree.py
@@ -261,6 +261,9 @@ class TreeNode(object):
         self.func = func
         self.namespace = namespace
 
+        # this will be constructed in the head of eval_tree
+        self.replace_codeset = {}
+
         # maybe this variable will be needed for user-friendly interface
         self.false_reason = ''
 
@@ -357,6 +360,12 @@ class TreeNode(object):
             None
         """
 
+        # If replace codeset is empty, construct it first
+        if not self.replace_codeset:
+            for course in taken_list:
+                code = course['code']
+                self.replace_codeset[code] = [replace.to_code for replace in Replace.objects.filter(from_code=code)]
+
         # First, evaluate all children so that itself can be evaluated directly
         for i, child in enumerate(self.children):
             if isinstance(child, TreeNode):
@@ -418,8 +427,9 @@ class TreeNode(object):
                 # fetch code number of taken course
                 code = course['code']
 
+                codeset = [code] + self.replace_codeset[code]
                 # If code matches to self.data, it will be evaluated to True
-                if code == self.data:
+                if self.data in codeset:
                     logger.debug('{data} returns True'.format(data=self.data))
                     self.data = True
                     is_satisfied = True

--- a/backend/core/rule/tree.py
+++ b/backend/core/rule/tree.py
@@ -347,7 +347,7 @@ class TreeNode(object):
     def add_children(self, obj):
         self.children.append(obj)
 
-    def eval_children(self, taken_list):
+    def eval_children(self, taken_list, replace_codeset=None):
         """Evaluate children recursively
 
         Evaluate TreeNode and set self.data to its value.
@@ -361,7 +361,7 @@ class TreeNode(object):
         """
 
         # If replace codeset is empty, construct it first
-        if not self.replace_codeset:
+        if replace_codeset is None:
             for course in taken_list:
                 code = course['code']
                 self.replace_codeset[code] = [replace.to_code for replace in Replace.objects.filter(from_code=code)]
@@ -369,7 +369,7 @@ class TreeNode(object):
         # First, evaluate all children so that itself can be evaluated directly
         for i, child in enumerate(self.children):
             if isinstance(child, TreeNode):
-                child.eval_children(taken_list)
+                child.eval_children(taken_list, self.replace_codeset)
 
         # If it is not course, which is not course code number, it should be
         # evaluated through `func`, because it is not directly able to be evaluated
@@ -427,7 +427,7 @@ class TreeNode(object):
                 # fetch code number of taken course
                 code = course['code']
 
-                codeset = [code] + self.replace_codeset[code]
+                codeset = [code] + replace_codeset[code]
                 # If code matches to self.data, it will be evaluated to True
                 if self.data in codeset:
                     logger.debug('{data} returns True'.format(data=self.data))


### PR DESCRIPTION
By using `Replace` model, now it can evaluate tree with replacable codes.

Codeset from `Replace` is cached at the very first evaluation process.

Performance is not pretty bad(about 0.35s -> 0.8s), but it can maybe improved by refactoring `Replace` model.

But first, I implemented tree evaluation using current `Replace` model straightforward.