### PR TITLE
Now treetest command can get file argument for taken_list

### DIFF
--- a/backend/core/management/commands/treetest.py
+++ b/backend/core/management/commands/treetest.py
@@ -3,22 +3,40 @@ from core.rule.tree import TreeLoader
 from crawler.mysnu import crawl_taken_list
 from getpass import getpass
 from time import time
+import pickle
 
 
 class Command(BaseCommand):
     help = 'tree tester.'
 
-    def handle(self, *args, **options):
-        username = input('mySNU username: ')
-        password = getpass('mySNU password: ')
+    def add_arguments(self, parser):
+        parser.add_argument('-f', '--file',
+                            help='custom taken_list pickle file',
+                            required=False)
 
-        t = time()
-        self.stdout.write('logging in to mysnu...')
-        taken_list = crawl_taken_list(username, password)
-        if not taken_list:
-            self.stdout.write('error: invalid credential.')
-            return
-        self.stdout.write('mySNU login elasped time: ' + str(time() - t) + 's')
+    def handle(self, *args, **options):
+
+        taken_list = {}
+        taken_list_file = options.get('file', None)
+
+        if taken_list_file is None:
+            username = input('mySNU username: ')
+            password = getpass('mySNU password: ')
+
+            t = time()
+            self.stdout.write('logging in to mysnu...')
+            taken_list = crawl_taken_list(username, password)
+            if not taken_list:
+                self.stdout.write('error: invalid credential.')
+                return
+            self.stdout.write('mySNU login elasped time: ' + str(time() - t) + 's')
+        else:
+            f = open(taken_list_file, 'rb')
+            taken_list = pickle.load(f).get('credit_info', None)
+
+            if taken_list is None:
+                self.stderr.write('file is not valid.')
+                return
 
         rule = input('rule name: ')
         teps = input('teps: ')

--- a/backend/core/management/commands/treetest.py
+++ b/backend/core/management/commands/treetest.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
             self.stdout.write('logging in to mysnu...')
             taken_list = crawl_taken_list(username, password)
             if not taken_list:
-                self.stdout.write('error: invalid credential.')
+                self.stderr.write('error: invalid credential.')
                 return
             self.stdout.write('mySNU login elasped time: ' + str(time() - t) + 's')
         else:


### PR DESCRIPTION
Now treetest command can get file argument by `-f` or `--file` command line argument.

Implemented for testing tree evaluation.