### PR TITLE
treetest command now shows load and eval time seperately

### DIFF
--- a/backend/core/management/commands/treetest.py
+++ b/backend/core/management/commands/treetest.py
@@ -48,6 +48,8 @@ class Command(BaseCommand):
 
         t = time()
         tree_node = TreeLoader(rule, metadata)
+        self.stdout.write('TreeLoader elasped time: ' + str(time() - t) + 's')
+        t = time()
         tree_node.eval_tree(taken_list)
         self.stdout.write(tree_node.tree_into_str())
-        self.stdout.write('TreeLoader elasped time: ' + str(time() - t) + 's')
+        self.stdout.write('Tree evaluation elasped time: ' + str(time() - t) + 's')


### PR DESCRIPTION
Small change, but big discovery.

With this change, I could figure out that speed bottleneck was TreeLoader, not eval_children.